### PR TITLE
Release v1.0.6

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,13 +1,22 @@
-## 1.0.5 - 2022-08-29
+
+### Unreleased
+
+
+### 1.0.5 - 2022-08-29
 
 - fix #2 change Spamhaus defaults to not assume errors as positives
 - warn instead of debug when result do not validate
 
-## 1.0.4 - 2022-07-23
+
+### [1.0.4] - 2022-07-23
 
 - updated package.json
 
 
-## 1.0.3 - 2022-07-23
+### 1.0.3 - 2022-07-23
 
 - Import from Haraka
+
+
+[1.0.4]: https://github.com/haraka/haraka-plugin-uribl/releases/tag/1.0.4
+[1.0.6]: https://github.com/haraka/haraka-plugin-uribl/releases/tag/1.0.6

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 
 ### Unreleased
 
+### 1.0.6 - 2022-11-28
+
+- test: increase timeout for DNSBL test
+
 
 ### 1.0.5 - 2022-08-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-uribl",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Haraka plugin that checks domains in emails against URI blacklists",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "haraka-net-utils": "^1.4.1",
-    "haraka-tld": "^1.0.34",
+    "haraka-tld": "^1.1.0",
     "haraka-utils": "^1.0.3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -25,10 +25,9 @@ describe('uribl', function () {
 })
 
 describe('load_uribl_ini', function () {
-  it('loads uribl.ini from config/uribl.ini', function (done) {
+  it('loads uribl.ini from config/uribl.ini', function () {
     this.plugin.load_uribl_ini()
     assert.equal(this.plugin.cfg.main.max_uris_per_list, 20)
-    done()
   })
 })
 
@@ -49,7 +48,9 @@ describe('do_lookups', function () {
   })
 
   it('lookup_test_ip: test.uribl.com', function (done) {
+    this.timeout(4000)
     this.plugin.do_lookups(this.connection, (code, msg) => {
+      if (code) console.log(`code: ${code}, ${msg}`)
       assert.equal(code, undefined)
       assert.equal(msg, undefined)
       done()


### PR DESCRIPTION
- fix #2 change Spamhaus defaults to not assume errors as positives
- warn instead of debug when result do not validate
- test: increase timeout for DNSBL test