### PR TITLE
add support for spamhaus DQS

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 
 ### Unreleased
 
+### 1.0.7 - 2023-01-05
+
+- handle Spamhaus DQS (#5): add a dqs_key config option and a [dbl.dq.spamhaus.net] zone, disabled by default
+
 ### 1.0.6 - 2022-11-28
 
 - test: increase timeout for DNSBL test

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ The following are optional for each list:
 
   Specifies that the list requires hostnames be stripped down to the domain boundaries prior to querying the list.  This is required for the [SURBL][3] and [URIBL][4] lists.
 
+Spamhaus DQS
+------------
+
+* dqs_key
+
+DQS key for Spamhaus's DQS mirrors.
+
 Other files
 -----------
 

--- a/config/uribl.ini
+++ b/config/uribl.ini
@@ -2,6 +2,12 @@
 ; not_ipv6_compatible=1
 [main]
 
+; spamhaus via Datafeed Query Service (DQS), requires a DQS key. To use, uncomment the
+; next two lines, configure the dqs_key, and comment out the standard spamhaus.
+;[dbl.dq.spamhaus.net]
+;dqs_key=abcdefghijklmnopq123456789
+
+; spamhaus via standard DNSBL. Comment out the next line when using DQS
 [dbl.spamhaus.org]
 validate=^(?!127\.0\.1\.255|127\.255\.255\.)127\.
 ; excluding errors, see https://www.spamhaus.org/faq/section/Spamhaus%20DBL#291

--- a/index.js
+++ b/index.js
@@ -170,6 +170,9 @@ exports.do_lookups = function (connection, next, hosts, type) {
       }
 
       if (!lookup) continue;
+      if (plugin.cfg[zone].dqs_key) {
+        lookup = `${lookup}.${plugin.cfg[zone].dqs_key}`;
+      }
       if (!queries[zone]) queries[zone] = {};
       if (Object.keys(queries[zone]).length > plugin.cfg.main.max_uris_per_list) {
         connection.logwarn(plugin, `discarding lookup ${lookup} for zone ${zone} maximum query limit reached`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-uribl",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Haraka plugin that checks domains in emails against URI blacklists",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #5. Tested using https://blt.spamhaus.com/.

Changes proposed in this pull request:
- add a `dqs_key` config option
- add a `[dbl.dq.spamhaus.net]` zone, commented by default

Checklist:
- [x] docs updated
- [ ] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
